### PR TITLE
Use standard hash function during installation procedure

### DIFF
--- a/install/step4.php
+++ b/install/step4.php
@@ -9,40 +9,24 @@
   define('Install', '');
   define('BASEPATH', 'Staff');
   require_once('../applications/wrapper.php');
-
-  function randomString($length) {
-      $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-      $randomString = '';
-      for ($i = 0; $i < $length; $i++) {
-          $randomString .= $characters[rand(0, strlen($characters) - 1)];
-      }
-      return $randomString;
-  }
-  function encrypt($password) {
-      $salty    = randomString(16);
-      $salt     = hash('sha256', $salty);
-      $password = hash('sha256', $password);
-      $password = hash('sha256', $password . $salt);
-      return '$SHA$' . $salty . '$' . $password;
-      //return $password;
-  }
+  require_once('../applications/functions.php');
 
   if( isset($_POST['continue']) ) {
       try {
-          
+
           foreach( $_POST as $parent => $child ) {
               $_POST[$parent] = htmlentities($child);
           }
-          
+
           $username = $_POST['username'];
           $password = encrypt($_POST['password']);
           $email    = $_POST['email'];
           $date     = time();
-          
+
           if( !$username or !$password or !$email ) {
               throw new Exception ('All fields are required!');
           } else {
-              
+
               $data = array(
                   'username' => $username,
                   'user_password' => $password,
@@ -50,15 +34,15 @@
                   'date_joined' => $date,
                   'user_group' => ADMIN_ID
               );
-              
+
               if( $MYSQL->insert('{prefix}users', $data) ) {
                   echo '<div class="alert alert-success">TangoBB has been successfully installed! Please delete the installation folder.</div>';
               } else {
                   throw new Exception ('Error inserting user into database!');
               }
-              
+
           }
-          
+
       } catch ( Exception $e ) {
           echo '<div class="alert alert-danger">' . $e->getMessage() . '</div>';
       }


### PR DESCRIPTION
For some reason, there was an extra function for hashing the password of the initial user. Replace it with the standard hash function.
