### PR TITLE
Introduced strong random number generator

### DIFF
--- a/applications/classes/session.php
+++ b/applications/classes/session.php
@@ -129,7 +129,7 @@
           $MYSQL->where('user_email', $email);
           $query      = $MYSQL->get('{prefix}users');
           
-          $session_id = randomString();
+          $session_id = randomHexBytes(16);
           $time       = time();
           
           if( $facebook ) {

--- a/applications/commands/members/forgetpassword.php
+++ b/applications/commands/members/forgetpassword.php
@@ -29,7 +29,7 @@
               throw new Exception ($LANG['global_form_process']['email_not_exist']);
           } else {
               
-              $new_password = randomString(9);
+              $new_password = randomHexBytes(16);
               $enc_password = encrypt($new_password);
               $data         = array(
                   'user_password' => $enc_password


### PR DESCRIPTION
rand() and mt_rand() produce weak random numbers and are not suitable for security purposes. Replace them with a secure PRNG if possible and deprecate randomString().
