### PR TITLE
Deactivate expiry of anti-CSRF tokens

### DIFF
--- a/admin/edit_category.php
+++ b/admin/edit_category.php
@@ -22,7 +22,7 @@
                       $_POST[$parent] = clean($child);
                   }
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   $title = $_POST['cat_title'];
                   $desc  = (!$_POST['cat_desc'])? '' : $_POST['cat_desc'];

--- a/admin/edit_node.php
+++ b/admin/edit_node.php
@@ -42,7 +42,7 @@
                       $_POST[$parent] = clean($child);
                   }
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   $title          = $_POST['node_title'];
                   $desc           = (!$_POST['node_desc'])? '' : $_POST['node_desc'];

--- a/admin/edit_usergroup.php
+++ b/admin/edit_usergroup.php
@@ -39,7 +39,7 @@
           if( isset($_POST['update']) ) {
               try {
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   $name   = clean($_POST['g_name']);
                   $style  = $_POST['g_style'];

--- a/admin/general.php
+++ b/admin/general.php
@@ -30,7 +30,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $site_name   = $_POST['site_name'];
           $board_email = $_POST['board_email'];

--- a/admin/manage_category.php
+++ b/admin/manage_category.php
@@ -37,7 +37,7 @@
               $_POST[$parent] = clean($value);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $place = $_POST['cat_place'];
           $p_cat = $_POST['cat_id'];

--- a/admin/manage_node.php
+++ b/admin/manage_node.php
@@ -93,7 +93,7 @@
               $_POST[$parent] = clean($value);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $place  = $_POST['node_place'];
           $p_node = $_POST['node_id'];

--- a/admin/new_category.php
+++ b/admin/new_category.php
@@ -14,7 +14,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $title = $_POST['cat_title'];
           $desc  = (!$_POST['cat_desc'])? '' : $_POST['cat_desc'];

--- a/admin/new_node.php
+++ b/admin/new_node.php
@@ -30,7 +30,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $title  = $_POST['node_title'];
           $desc   = (!$_POST['node_desc'])? '' : $_POST['node_desc'];

--- a/admin/new_usergroup.php
+++ b/admin/new_usergroup.php
@@ -29,7 +29,7 @@
   if( isset($_POST['new']) ) {
       try {
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $name  = clean($_POST['g_name']);
           $style = $_POST['g_style'];
           

--- a/applications/commands/conversations/reply.php
+++ b/applications/commands/conversations/reply.php
@@ -25,7 +25,7 @@
       			$_POST[$parent] = clean($child);
       		}
 
-      		NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+      		NoCSRF::check( 'csrf_token', $_POST );
       		$cont = clean($_POST['content']);
       		$time = time();
 

--- a/applications/commands/members/forgotpassword.php
+++ b/applications/commands/members/forgotpassword.php
@@ -21,7 +21,7 @@
 
           $email = $_POST['email'];
 
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
 
           if( !$email ) {
               throw new Exception ($LANG['global_form_process']['all_fields_required']);

--- a/applications/commands/members/register.php
+++ b/applications/commands/members/register.php
@@ -17,7 +17,7 @@
                     $_POST[$parent] = clean($child);
                 }
                 
-                NoCSRF::check('csrf_token', $_POST, true, 60*10, true);//CSRF Checking.
+                NoCSRF::check('csrf_token', $_POST);//CSRF Checking.
                 $username   = $_POST['username'];
                 $password   = $_POST['password'];
                 $a_password = $_POST['a_password'];

--- a/applications/commands/members/resetpassword.php
+++ b/applications/commands/members/resetpassword.php
@@ -42,7 +42,7 @@ try {
             $_POST[$parent] = clean($child);
         }
 
-        NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+        NoCSRF::check( 'csrf_token', $_POST );
         $password   = $_POST['password'];
         $a_password = $_POST['a_password'];
 

--- a/applications/commands/profile/edit.php
+++ b/applications/commands/profile/edit.php
@@ -18,7 +18,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $email = $_POST['email'];
           $tz    = $_POST['timezone'];
           $pass  = $_POST['confirm_password'];

--- a/applications/commands/profile/password.php
+++ b/applications/commands/profile/password.php
@@ -18,7 +18,7 @@
               $_POST[$parent] = clean($child);
           }
 
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $new_password = $_POST['new_password'];
           $con_password = $_POST['current_password'];
 

--- a/applications/commands/profile/signature.php
+++ b/applications/commands/profile/signature.php
@@ -18,7 +18,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $sig = $_POST['sig'];
           
           if( !$sig ) {

--- a/edit.php
+++ b/edit.php
@@ -112,7 +112,7 @@
           if( isset($_POST['edit']) ) {
               try {
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   //$con = $MYSQL->escape($_POST['content']);
                   //die($con);

--- a/new.php
+++ b/new.php
@@ -91,7 +91,7 @@
           if( isset($_POST['create']) ) {
               try {
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   $thread_title = clean($_POST['title']);
                   //die($_POST['content']);
                   $thread_cont  = $_POST['content'];

--- a/reply.php
+++ b/reply.php
@@ -117,7 +117,7 @@
                           throw new Exception ('Invalid CSRF token!');
                       }
                   } else {
-                      NoCSRF::check('csrf_token', $_POST, true, 60*10, true);
+                      NoCSRF::check('csrf_token', $_POST);
                   }
                   
                   $cont    = $_POST['content'];

--- a/report.php
+++ b/report.php
@@ -24,7 +24,7 @@
                       $_POST[$parent] = clean($child);
                   }
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   $reason = $_POST['reason'];
                   
                   if( !$reason ) {


### PR DESCRIPTION
If the tokens expire after a short amount of time, users permanently run into trouble when trying to submit a form. In the worst case, they write a long text and then lose everything due to an expired token. This is obviously a problem.

It also doesn't make a lot of sense from a security perspective. The anti-CSRF tokens are less important than the session ID, so there's no reason for rotating them more often.
