### PR TITLE
Mysqli error handling

### DIFF
--- a/admin/edit_category.php
+++ b/admin/edit_category.php
@@ -8,43 +8,44 @@
   $notice = '';
 
   if( $PGET->g('id') ) {
-      
+
       $id    = clean($PGET->g('id'));
       $MYSQL->where('id', $id);
       $query = $MYSQL->get('{prefix}forum_category');
-      
+
       if( !empty($query) ) {
-          
+
           if( isset($_POST['update']) ) {
               try {
-                  
+
                   foreach( $_POST as $parent => $child ) {
                       $_POST[$parent] = clean($child);
                   }
-                  
+
                   NoCSRF::check( 'csrf_token', $_POST );
-                  
+
                   $title = $_POST['cat_title'];
                   $desc  = (!$_POST['cat_desc'])? '' : $_POST['cat_desc'];
-                  
+
                   if( !$title ) {
                       throw new Exception ('All fields are required!');
                   } else {
-                      
+
                       $data = array(
                           'category_title' => $title,
                           'category_desc' => $desc
                       );
                       $MYSQL->where('id', $id);
-                      
-                      if( $MYSQL->update('{prefix}forum_category', $data) ) {
+
+                      try {
+                          $MYSQL->update('{prefix}forum_category', $data);
                           redirect(SITE_URL . '/admin/manage_category.php/notice/edit_success');
-                      } else {
+                      } catch (mysqli_sql_exception $e) {
                           throw new Exception ('Error updating category.');
                       }
-                      
+
                   }
-                  
+
               } catch (Exception $e) {
                   $notice .= $ADMIN->alert(
                       $e->getMessage(),
@@ -52,9 +53,9 @@
                   );
               }
           }
-          
+
           $token = NoCSRF::generate('csrf_token');
-          
+
           echo $ADMIN->box(
               'Edit Category (' . $query['0']['category_title'] . ') <p class="pull-right"><a href="' . SITE_URL . '/admin/manage_category.php" class="btn btn-default btn-xs">Back</a></p>',
               $notice .
@@ -70,11 +71,11 @@
               '',
               '12'
           );
-          
+
       } else {
           redirect(SITE_URL . '/admin');
       }
-      
+
   } else {
       redirect(SITE_URL . '/admin');
   }

--- a/admin/edit_category.php
+++ b/admin/edit_category.php
@@ -22,7 +22,7 @@
                       $_POST[$parent] = clean($child);
                   }
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   $title = $_POST['cat_title'];
                   $desc  = (!$_POST['cat_desc'])? '' : $_POST['cat_desc'];

--- a/admin/edit_node.php
+++ b/admin/edit_node.php
@@ -28,26 +28,26 @@
   }
 
   if( $PGET->g('id') ) {
-      
+
       $id    = clean($PGET->g('id'));
       $MYSQL->where('id', $id);
       $query = $MYSQL->get('{prefix}forum_node');
-      
+
       if( !empty($query) ) {
-          
+
           if( isset($_POST['update']) ) {
               try {
-                  
+
                   foreach( $_POST as $parent => $child ) {
                       $_POST[$parent] = clean($child);
                   }
-                  
+
                   NoCSRF::check( 'csrf_token', $_POST );
-                  
+
                   $title          = $_POST['node_title'];
                   $desc           = (!$_POST['node_desc'])? '' : $_POST['node_desc'];
                   $locked         = (isset($_POST['lock_node']))? '1' : '0';
-                  
+
                   if( !$title ) {
                       throw new Exception ('All fields are required!');
                   } else {
@@ -73,17 +73,18 @@
                         'node_type' => 1
                       );
                     }
-                      
+
                       $MYSQL->where('id', $id);
-                      
-                      if( $MYSQL->update('{prefix}forum_node', $data) ) {
+
+                      try {
+                          $MYSQL->update('{prefix}forum_node', $data);
                           redirect(SITE_URL . '/admin/manage_node.php/notice/edit_success');
-                      } else {
+                      } catch (mysqli_sql_exception $e) {
                           throw new Exception ('Error updating node.');
                       }
-                      
+
                   }
-                  
+
               } catch (Exception $e) {
                   $notice .= $ADMIN->alert(
                       $e->getMessage(),
@@ -122,11 +123,11 @@
               '',
               '12'
           );
-          
+
       } else {
           redirect(SITE_URL . '/admin');
       }
-      
+
   } else {
       redirect(SITE_URL . '/admin');
   }

--- a/admin/edit_node.php
+++ b/admin/edit_node.php
@@ -42,7 +42,7 @@
                       $_POST[$parent] = clean($child);
                   }
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   $title          = $_POST['node_title'];
                   $desc           = (!$_POST['node_desc'])? '' : $_POST['node_desc'];

--- a/admin/edit_usergroup.php
+++ b/admin/edit_usergroup.php
@@ -29,21 +29,21 @@
   }
 
   if( $PGET->g('id') ) {
-      
+
       $id    = clean($PGET->g('id'));
       $MYSQL->where('id', $id);
       $query = $MYSQL->get('{prefix}usergroups');
-      
+
       if( !empty($query) ) {
-          
+
           if( isset($_POST['update']) ) {
               try {
-                  
+
                   NoCSRF::check( 'csrf_token', $_POST );
-                  
+
                   $name   = clean($_POST['g_name']);
                   $style  = $_POST['g_style'];
-                  
+
                   if( list_permissions() == $_POST['permissions'] ) {
                       $permissions = '*';
                   } elseif( empty($_POST['permissions']) ) {
@@ -51,28 +51,29 @@
                   } else {
                       $permissions = implode(',', $_POST['permissions']);
                   }
-                  
+
                   $permissions = clean($permissions);
-                  
+
                   if( !$name or !$style ) {
                       throw new Exception ('All fields are required!');
                   } else {
-                      
+
                       $data = array(
                           'group_name' => $name,
                           'group_style' => $style,
                           'group_permissions' => $permissions
                       );
                       $MYSQL->where('id', $id);
-                      
-                      if( $MYSQL->update('{prefix}usergroups', $data) ) {
+
+                      try {
+                          $MYSQL->update('{prefix}usergroups', $data);
                           redirect(SITE_URL . '/admin/usergroups.php/notice/edit_success');
-                      } else {
+                      } catch (mysqli_sql_exception $e) {
                           throw new Exception ('Error updating usergroup.');
                       }
-                      
+
                   }
-                  
+
               } catch (Exception $e) {
                   $notice .= $ADMIN->alert(
                       $e->getMessage(),
@@ -80,9 +81,9 @@
                   );
               }
           }
-          
+
           $token = NoCSRF::generate('csrf_token');
-          
+
           echo $ADMIN->box(
               'Edit Usergroup (' . $query['0']['group_name'] . ') <p class="pull-right"><a href="' . SITE_URL . '/admin/usergroups.php" class="btn btn-default btn-xs">Back</a></p>',
               $notice .
@@ -100,11 +101,11 @@
               '',
               '12'
           );
-          
+
       } else {
           redirect(SITE_URL . '/admin');
       }
-      
+
   } else {
       redirect(SITE_URL . '/admin');
   }

--- a/admin/edit_usergroup.php
+++ b/admin/edit_usergroup.php
@@ -39,7 +39,7 @@
           if( isset($_POST['update']) ) {
               try {
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   $name   = clean($_POST['g_name']);
                   $style  = $_POST['g_style'];

--- a/admin/extensions.php
+++ b/admin/extensions.php
@@ -35,7 +35,9 @@
             'extension_folder' => $ext
           );
 
-          if( !$MYSQL->insert('{prefix}extensions', $data) ) {
+          try {
+              $MYSQL->insert('{prefix}extensions', $data);
+          } catch (mysqli_sql_exception $e) {
             $notice .= $ADMIN->alert(
               'Error installing extension.',
               'danger'
@@ -91,7 +93,9 @@
         $setup = new Extension_Setup();
 
         $MYSQL->where('extension_folder', $ext);
-        if( !$MYSQL->delete('{prefix}extensions') ) {
+        try {
+            $MYSQL->delete('{prefix}extensions');
+        } catch (mysqli_sql_exception $e) {
           $notice .= $ADMIN->alert(
             'Error installing extension.',
             'danger'

--- a/admin/general.php
+++ b/admin/general.php
@@ -30,7 +30,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $site_name   = $_POST['site_name'];
           $board_email = $_POST['board_email'];

--- a/admin/general.php
+++ b/admin/general.php
@@ -25,13 +25,13 @@
 
   if( isset($_POST['update']) ) {
       try {
-          
+
           foreach( $_POST as $parent => $child ) {
               $_POST[$parent] = clean($child);
           }
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
-          
+
           $site_name   = $_POST['site_name'];
           $board_email = $_POST['board_email'];
           $site_lang   = $_POST['default_language'];
@@ -39,11 +39,11 @@
           $fb_app_id   = $_POST['fb_app_id'];
           $fb_app_sec  = $_POST['fb_app_secret'];
           $enable_fb   = (isset($_POST['enable_facebook']))? '1' : '0';
-          
+
           if( !$site_name or !$board_email or !$site_lang ) {
               throw new Exception ('All fields are required!');
           } else {
-              
+
               $data = array(
                   'site_name' => $site_name,
                   'site_email' => $board_email,
@@ -53,18 +53,19 @@
                   'facebook_authenticate' => $enable_fb
               );
               $MYSQL->where('id', 1);
-              
-              if( $MYSQL->update('{prefix}generic', $data) ) {
+
+              try {
+                  $MYSQL->update('{prefix}generic', $data);
                   $notice .= $ADMIN->alert(
                       'Informations saved!',
                       'success'
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ('Error saving information. Try again later.');
               }
-              
+
           }
-          
+
       } catch (Exception $e) {
           $notice .= $ADMIN->alert(
               $e->getMessage(),
@@ -74,7 +75,7 @@
   }
 
   $token = NoCSRF::generate('csrf_token');
-     
+
   echo '<form action="" method="POST">';
 
   echo $ADMIN->box(

--- a/admin/manage_category.php
+++ b/admin/manage_category.php
@@ -79,12 +79,13 @@
       if( !empty($query) ) {
 
           $MYSQL->where('id', $d_cat);
-          if( $MYSQL->delete('{prefix}forum_category') ) {
+          try {
+              $MYSQL->delete('{prefix}forum_category');
               $notice .= $ADMIN->alert(
                   'Category <strong>' . $query['0']['category_title'] . '</strong> has been deleted!',
                   'success'
               );
-          } else {
+          } catch (mysqli_sql_exception $e) {
               $notice .= $ADMIN->alert(
                   'Error deleting category.',
                   'danger'

--- a/admin/manage_category.php
+++ b/admin/manage_category.php
@@ -37,7 +37,7 @@
               $_POST[$parent] = clean($value);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $place = $_POST['cat_place'];
           $p_cat = $_POST['cat_id'];

--- a/admin/manage_category.php
+++ b/admin/manage_category.php
@@ -32,16 +32,16 @@
    */
   if( isset($_POST['change_place']) ) {
       try {
-          
+
           foreach( $_POST as $parent => $value ) {
               $_POST[$parent] = clean($value);
           }
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
-          
+
           $place = $_POST['cat_place'];
           $p_cat = $_POST['cat_id'];
-          
+
           if( !$place or !$p_cat ) {
               throw new Exception ('All fields are required!');
           } else {
@@ -49,16 +49,17 @@
                   'category_place' => $place
               );
               $MYSQL->where('id', $p_cat);
-              if( $MYSQL->update('{prefix}forum_category', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}forum_category', $data);
                   $notice .= $ADMIN->alert(
                       'Category place has been updated!',
                       'success'
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ('Error updating category place.');
               }
           }
-          
+
       } catch( Exception $e ) {
           $notice .= $ADMIN->alert(
               $e->getMessage(),
@@ -74,9 +75,9 @@
       $d_cat = clean($PGET->g('delete_category'));
       $MYSQL->where('id', $d_cat);
       $query = $MYSQL->get('{prefix}forum_category');
-      
+
       if( !empty($query) ) {
-          
+
           $MYSQL->where('id', $d_cat);
           if( $MYSQL->delete('{prefix}forum_category') ) {
               $notice .= $ADMIN->alert(
@@ -89,7 +90,7 @@
                   'danger'
               );
           }
-          
+
       } else {
           $notice .= $ADMIN->alert(
               'Category does not exist!',

--- a/admin/manage_node.php
+++ b/admin/manage_node.php
@@ -64,12 +64,13 @@
       if( !empty($query) ) {
 
           $MYSQL->where('id', $d_node);
-          if( $MYSQL->delete('{prefix}forum_node') ) {
+          try {
+              $MYSQL->delete('{prefix}forum_node');
               $notice .= $ADMIN->alert(
                   'Node <strong>' . $query['0']['node_name'] . '</strong> has been deleted!',
                   'success'
               );
-          } else {
+          } catch (mysqli_sql_exception $e) {
               $notice .= $ADMIN->alert(
                   'Error deleting node.',
                   'danger'

--- a/admin/manage_node.php
+++ b/admin/manage_node.php
@@ -93,7 +93,7 @@
               $_POST[$parent] = clean($value);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $place  = $_POST['node_place'];
           $p_node = $_POST['node_id'];

--- a/admin/manage_node.php
+++ b/admin/manage_node.php
@@ -39,12 +39,13 @@
           'node_locked' => $lock
       );
       $MYSQL->where('id', $id);
-      if( $MYSQL->update('{prefix}forum_node', $data) ) {
+      try {
+          $MYSQL->update('{prefix}forum_node', $data);
           $notice .= $ADMIN->alert(
               'Lock has successfully been toggled on node <strong>' . $query['0']['node_name'] . '</strong>.',
               'success'
           );
-      } else {
+      } catch (mysqli_sql_exception $e) {
           $notice .= $ADMIN->alert(
               'Error toggling lock on node <strong>' . $query['0']['node_name'] . '</strong>.',
               'danger'
@@ -59,9 +60,9 @@
       $d_node = clean($PGET->g('delete_node'));
       $MYSQL->where('id', $d_node);
       $query  = $MYSQL->get('{prefix}forum_node');
-      
+
       if( !empty($query) ) {
-          
+
           $MYSQL->where('id', $d_node);
           if( $MYSQL->delete('{prefix}forum_node') ) {
               $notice .= $ADMIN->alert(
@@ -74,7 +75,7 @@
                   'danger'
               );
           }
-          
+
       } else {
           $notice .= $ADMIN->alert(
               'Node does not exist!',
@@ -88,16 +89,16 @@
    */
   if( isset($_POST['change_place']) ) {
       try {
-          
+
           foreach( $_POST as $parent => $value ) {
               $_POST[$parent] = clean($value);
           }
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
-          
+
           $place  = $_POST['node_place'];
           $p_node = $_POST['node_id'];
-          
+
           if( !$place or !$p_node ) {
               throw new Exception ('All fields are required!');
           } else {
@@ -105,16 +106,17 @@
                   'node_place' => $place
               );
               $MYSQL->where('id', $p_node);
-              if( $MYSQL->update('{prefix}forum_node', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}forum_node', $data);
                   $notice .= $ADMIN->alert(
                       'Node place has been updated!',
                       'success'
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ('Error updating node place.');
               }
           }
-          
+
       } catch( Exception $e ) {
           $notice .= $ADMIN->alert(
               $e->getMessage(),

--- a/admin/new_category.php
+++ b/admin/new_category.php
@@ -9,33 +9,34 @@
 
   if( isset($_POST['create']) ) {
       try {
-          
+
           foreach( $_POST as $parent => $child ) {
               $_POST[$parent] = clean($child);
           }
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
-          
+
           $title = $_POST['cat_title'];
           $desc  = (!$_POST['cat_desc'])? '' : $_POST['cat_desc'];
-          
+
           if( !$title ) {
               throw new Exception ('All fields are required!');
           } else {
-              
+
               $data = array(
                   'category_title' => $title,
                   'category_desc' => $desc
               );
-              
-              if( $MYSQL->insert('{prefix}forum_category', $data) ) {
+
+              try {
+                  $MYSQL->insert('{prefix}forum_category', $data);
                   redirect(SITE_URL . '/admin/manage_category.php/notice/create_success');
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ('Error creating forum category.');
               }
-              
+
           }
-          
+
       } catch ( Exception $e ) {
           $notice .= $ADMIN->alert(
               $e->getMessage(),
@@ -60,7 +61,7 @@
        </form>',
               '',
               '12'
-          );  
+          );
 
   require_once('template/bot.php');
 ?>

--- a/admin/new_category.php
+++ b/admin/new_category.php
@@ -14,7 +14,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $title = $_POST['cat_title'];
           $desc  = (!$_POST['cat_desc'])? '' : $_POST['cat_desc'];

--- a/admin/new_node.php
+++ b/admin/new_node.php
@@ -30,7 +30,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           
           $title  = $_POST['node_title'];
           $desc   = (!$_POST['node_desc'])? '' : $_POST['node_desc'];

--- a/admin/new_node.php
+++ b/admin/new_node.php
@@ -25,21 +25,21 @@
 
   if( isset($_POST['create']) ) {
       try {
-          
+
           foreach( $_POST as $parent => $child ) {
               $_POST[$parent] = clean($child);
           }
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
-          
+
           $title  = $_POST['node_title'];
           $desc   = (!$_POST['node_desc'])? '' : $_POST['node_desc'];
           $locked = (isset($_POST['lock_node']))? '1' : '0';
-          
+
           if( !$title ) {
               throw new Exception ('All fields are required!');
           } else {
-              
+
               if( substr_count($_POST['node_parent'], '&amp;') > 0 ) {
                 $explode = explode('&amp;', $_POST['node_parent']);
                 $parent  = node($explode['1']);
@@ -60,15 +60,16 @@
                   'node_type' => 1
                 );
               }
-              
-              if( $MYSQL->insert('{prefix}forum_node', $data) ) {
+
+              try {
+                  $MYSQL->insert('{prefix}forum_node', $data);
                   redirect(SITE_URL . '/admin/manage_node.php/notice/create_success');
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ('Error creating forum category.');
               }
-              
+
           }
-          
+
       } catch ( Exception $e ) {
           $notice .= $ADMIN->alert(
               $e->getMessage(),
@@ -100,7 +101,7 @@
        </form>',
               '',
               '12'
-          );  
+          );
 
   require_once('template/bot.php');
 ?>

--- a/admin/new_usergroup.php
+++ b/admin/new_usergroup.php
@@ -28,11 +28,11 @@
 
   if( isset($_POST['new']) ) {
       try {
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
           $name  = clean($_POST['g_name']);
           $style = $_POST['g_style'];
-          
+
           if( list_permissions() == $_POST['permissions'] ) {
               $permissions = '*';
           } elseif( empty($_POST['permissions']) ) {
@@ -40,9 +40,9 @@
           } else {
               $permissions = implode(',', $_POST['permissions']);
           }
-          
+
           $permissions = clean($permissions);
-          
+
           if( !$name or !$style ) {
               throw new Exception ('All fields are required!');
           } else {
@@ -51,14 +51,15 @@
                   'group_style' => $style,
                   'group_permissions' => $permissions
               );
-              
-              if( $MYSQL->insert('{prefix}usergroups', $data) ) {
+
+              try {
+                  $MYSQL->insert('{prefix}usergroups', $data);
                   redirect(SITE_URL . '/admin/usergroups.php/notice/create_success');
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ('Error creating usergroup.');
               }
           }
-          
+
       } catch ( Exception $e ) {
           $notice .= $ADMIN->alert(
               $e->getMessage(),
@@ -68,7 +69,7 @@
   }
 
   $token = NoCSRF::generate('csrf_token');
-   
+
   echo $ADMIN->box(
        'New Usergroup <p class="pull-right"><a href="' . SITE_URL . '/admin/usergroups.php" class="btn btn-default btn-xs">Back</a></p>',
        $notice .

--- a/admin/new_usergroup.php
+++ b/admin/new_usergroup.php
@@ -29,7 +29,7 @@
   if( isset($_POST['new']) ) {
       try {
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $name  = clean($_POST['g_name']);
           $style = $_POST['g_style'];
           

--- a/admin/terminal.php
+++ b/admin/terminal.php
@@ -9,17 +9,17 @@
 
   if( isset($_POST['run']) ) {
       try {
-          
+
           foreach( $_POST as $parent => $child ) {
               $_POST[$parent] = clean($child);
           }
-          
+
           $cmd = '/' . $_POST['command'];
-          
+
           if( !$cmd ) {
               throw new Exception ('Please enter a command.');
           } else {
-              
+
               if( $handle = opendir('../applications/terminal') ) {
                 while( false !== ($entry = readdir($handle)) ) {
                   if ($entry !== "." && $entry !== ".." && $entry !== 'index.html') {
@@ -41,9 +41,9 @@
               } else {
                 throw new Exception ('Command does not exist.');
               }
-              
+
               /*switch($command) {
-                  
+
                   case "cugroup":
                     //die($cmd);
                     list($del, $username, $ug) = sscanf($cmd, '/%s %s %s');
@@ -54,17 +54,18 @@
                             'user_group' => $g['id']
                         );
                         $MYSQL->where('username', $username);
-                        if( $MYSQL->update('{prefix}users', $data) ) {
+                        try {
+                            $MYSQL->update('{prefix}users', $data);
                             $notice .= $ADMIN->alert(
                                 'User\'s usergroup has been changed!',
                                 'success'
                             );
-                        } else {
+                        } catch (mysqli_sql_exception $e) {
                             throw new Exception ('Error changing user\'s usergroup.');
                         }
                     }
                   break;
-                  
+
                   case "ban":
                     list($del, $username) = sscanf($cmd, '/%s %s');
                     $data = array(
@@ -72,16 +73,17 @@
                         'user_group' => BAN_ID
                     );
                     $MYSQL->where('username', $username);
-                    if( $MYSQL->update('{prefix}users', $data) ) {
+                    try {
+                        $MYSQL->update('{prefix}users', $data);
                         $notice .= $ADMIN->alert(
                             'User has been banned!',
                             'success'
                         );
-                    } else {
+                    } catch (mysqli_sql_exception $e) {
                         throw new Exception ('Error banning user.');
                     }
                   break;
-                  
+
                   case "unban":
                     list($del, $username) = sscanf($cmd, '/%s %s');
                     $data = array(
@@ -89,24 +91,25 @@
                         'user_group' => 1
                     );
                     $MYSQL->where('username', $username);
-                    if( $MYSQL->update('{prefix}users', $data) ) {
+                    try {
+                        $MYSQL->update('{prefix}users', $data);
                         $notice .= $ADMIN->alert(
                             'User has been unbanned!',
                             'success'
                         );
-                    } else {
+                    } catch (mysqli_sql_exception $e) {
                         throw new Exception ('Error unbanning user.');
                     }
                   break;
-                  
+
                   default:
                     throw new Exception ('Command does not exist!');
                   break;
-                  
+
               }*/
-              
+
           }
-          
+
       } catch (Exception $e) {
           $notice .= $ADMIN->alert(
               $e->getMessage(),

--- a/admin/theme.php
+++ b/admin/theme.php
@@ -13,24 +13,25 @@
   if( $PGET->g('set_default') ) {
       $default = clean($PGET->g('set_default'));
       if( in_array($default, $directory) ) {
-          
+
           $data = array(
               'site_theme' => $default
           );
           $MYSQL->where('id', 1);
-          
-          if( $MYSQL->update('{prefix}generic', $data) ) {
+
+          try {
+              $MYSQL->update('{prefix}generic', $data);
               $notice .= $ADMIN->alert(
                   'Theme <strong>' . $default . '</strong> has been set as default!',
                   'success'
               );
-          } else {
+          } catch (mysqli_sql_exception $e) {
               $notice .= $ADMIN->alert(
                   'Error setting theme as default.',
                   'danger'
               );
           }
-          
+
       } else {
           $notice .= $ADMIN->alert(
               'Theme does not exist.',
@@ -42,7 +43,7 @@
   if( $PGET->g('delete_theme') ) {
       $theme = clean($PGET->g('delete_theme'));
       if( in_array($theme, $directory) ) {
-          
+
           if( rrmdir('../public/themes/' . $theme) ) {
               $notice .= $ADMIN->alert(
                   'Theme <strong>' . $theme . '</strong> has been deleted!',
@@ -54,7 +55,7 @@
                   'danger'
               );
           }
-          
+
       } else {
           $notice .= $ADMIN->alert(
               'Theme does not exist.',

--- a/admin/usergroups.php
+++ b/admin/usergroups.php
@@ -34,22 +34,23 @@
       $d_u   = clean($PGET->g('delete_usergroup'));
       $MYSQL->where('id', $d_u);
       $query = $MYSQL->get('{prefix}usergroups');
-      
+
       if( !empty($query) ) {
-          
+
           $MYSQL->where('id', $d_u);
-          if( $MYSQL->delete('{prefix}usergroups') ) {
+          try {
+              $MYSQL->delete('{prefix}usergroups');
               $notice .= $ADMIN->alert(
                   'Usergroup <strong>' . $query['0']['group_name'] . '</strong> has been deleted!',
                   'success'
               );
-          } else {
+          } catch (mysqli_sql_exception $e) {
               $notice .= $ADMIN->alert(
                   'Error deleting usergroup.',
                   'danger'
               );
           }
-          
+
       } else {
           $notice .= $ADMIN->alert(
               'Usergroup does not exist!',

--- a/applications/classes/session.php
+++ b/applications/classes/session.php
@@ -6,23 +6,23 @@
   if( !defined('BASEPATH') ){ die(); }
 
   class Tango_Session {
-      
+
       public $isLogged = false;
       public $data, $date;
       private $session;
-      
+
       public function __construct() {
           global $TANGO, $MYSQL;
           $this->clear();
           if( $this->check() ) {
               //die(var_dump($session_id));
               $this->isLogged               = true;
-              //$user_id                      = ( isset($_SESSION['tangobb_sess']) )? $_SESSION['tangobb_sess'] : $_COOKIE['tangobb_sess'];                                         
+              //$user_id                      = ( isset($_SESSION['tangobb_sess']) )? $_SESSION['tangobb_sess'] : $_COOKIE['tangobb_sess'];
               //$this->data                   = $TANGO->user($user_id);
               $this->data                   = $TANGO->user($this->session['logged_user']);
               $this->data['username_style'] = $TANGO->usergroup($this->data['user_group'], 'username_style', $this->data['username']);
               $this->data['permissions']    = $TANGO->usergroup($this->data['user_group'], 'permissions');
-              
+
               if( $this->session['session_time'] >= strtotime('24 hours ago') ) {
                 $time = time();
                 $MYSQL->where('session_id', $this->session['session_id']);
@@ -43,14 +43,14 @@
                   'Signature' => SITE_URL . '/profile.php/cmd/signature',
                   'Password' => SITE_URL . '/profile.php/cmd/password'
               ));
-              
+
               //Getting user's total post/messages.
               $MYSQL->where('post_user', $this->data['id']);
               $user_post_count = $MYSQL->get('{prefix}forum_posts');
               $user_post_count = number_format(count($user_post_count));
-              
+
               $mod_report_integer = modReportInteger();
-              
+
               $TANGO->tpl->addParam(
                   array(
                       'username',
@@ -80,13 +80,13 @@
               $TANGO->tpl->setTheme($TANGO->data['site_theme']);
           }
       }
-      
+
       /*
        * Check if session or cookie exists.
        */
       public function check() {
           global $MYSQL;
-          
+
           if( isset($_SESSION['tangobb_sess']) or isset($_COOKIE['tangobb_sess']) ) {
               $id = (isset($_SESSION['tangobb_sess']))? $_SESSION['tangobb_sess'] : $_COOKIE['tangobb_sess'];
               $MYSQL->where('session_id', $id);
@@ -101,7 +101,7 @@
               return false;
           }
       }
-      
+
       /*
        * Clear expired sessions.
        */
@@ -116,7 +116,7 @@
               }
           }
       }
-      
+
       /*
        * Assign session to user.
        * Session Type
@@ -125,55 +125,57 @@
        */
       public function assign($email, $remember = false, $facebook = false) {
           global $MYSQL;
-          
+
           $MYSQL->where('user_email', $email);
           $query      = $MYSQL->get('{prefix}users');
-          
+
           $session_id = randomHexBytes(16);
           $time       = time();
-          
+
           if( $facebook ) {
               setcookie('tangobb_facebook', true, time()+TANGO_SESSION_TIMEOUT, '/', NULL, isset($_SERVER['HTTPS']), true);
           }
-          
+
           if( $remember ) {
-              
+
               $data = array(
                   'session_id' => $session_id,
                   'logged_user' => $query['0']['id'],
                   'session_type' => '2',
                   'session_time' => $time
               );
-              if( $MYSQL->insert('{prefix}sessions', $data) ) {
+              try {
+                  $MYSQL->insert('{prefix}sessions', $data);
                   return setcookie('tangobb_sess', $session_id, time()+TANGO_SESSION_TIMEOUT, '/', NULL, isset($_SERVER['HTTPS']), true);
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   return false;
               }
-              
+
           } else {
-              
+
               $data = array(
                   'session_id' => $session_id,
                   'logged_user' => $query['0']['id'],
                   'session_type' => '1',
                   'session_time' => $time
               );
-              if( $MYSQL->insert('{prefix}sessions', $data) ) {
+              try {
+                  $MYSQL->insert('{prefix}sessions', $data);
                   $_SESSION['tangobb_sess'] = $session_id;
                   return true;
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   return false;
               }
-              
+
           }
       }
-      
+
       /*
        * Remove session to user.
        */
       public function remove() {
           global $MYSQL;
-          
+
           if( isset($_SESSION['tangobb_sess']) ) {
               $MYSQL->where('session_id', $_SESSION['tangobb_sess']);
               $MYSQL->delete('{prefix}sessions');
@@ -184,7 +186,7 @@
               return setcookie('tangobb_sess', '', time()-3600, '/', NULL, isset($_SERVER['HTTPS']), true);
           }
       }
-      
+
   }
 
 ?>

--- a/applications/classes/user.php
+++ b/applications/classes/user.php
@@ -6,9 +6,9 @@
   if( !defined('BASEPATH') ){ die(); }
 
   class Tango_User {
-      
+
       private $user_links = array();
-      
+
       public function __construct() {
       }
 
@@ -29,9 +29,10 @@
           );
           $MYSQL->where('id', $user);
 
-          if( $MYSQL->update('{prefix}users', $data) ) {
+          try {
+            $MYSQL->update('{prefix}users', $data);
             return true;
-          } else {
+          } catch (mysqli_sql_exception $e) {
             return false;
           }
 
@@ -53,9 +54,10 @@
             'username' => $username
           );
           $MYSQL->where('id', $user);
-          if( $MYSQL->update('{prefix}users', $data) ) {
+          try {
+            $MYSQL->update('{prefix}users', $data);
             return true;
-          } else {
+          } catch (mysqli_sql_exception $e) {
             return false;
           }
 
@@ -63,7 +65,7 @@
           return false;
         }
       }
-      
+
       /*
        * Return user links as an array.
        * For template use.
@@ -71,7 +73,7 @@
       function userLinks() {
           return $this->user_links;
       }
-      
+
       /*
        * Add link to the user links.
        */
@@ -80,7 +82,7 @@
               $this->user_links[$name] = $href;
           }
       }
-      
+
       /*
        * User messages.
        */
@@ -111,8 +113,8 @@
           }
           return $return;
       }
-      
-      
+
+
   }
 
 ?>

--- a/applications/commands/conversations/new.php
+++ b/applications/commands/conversations/new.php
@@ -50,7 +50,8 @@
             'message_type' => 1
           );
 
-          if( $MYSQL->insert('{prefix}messages', $data) ) {
+          try {
+              $MYSQL->insert('{prefix}messages', $data);
             $notice .= $TANGO->tpl->entity(
               'success_notice',
               'content',
@@ -60,7 +61,7 @@
                 $LANG['bb']['conversations']['message_sent']
               )
             );
-          } else {
+          } catch (mysqli_sql_exception $e) {
             throw new Exception (
               str_replace(
                 '%username%',

--- a/applications/commands/conversations/reply.php
+++ b/applications/commands/conversations/reply.php
@@ -25,7 +25,7 @@
       			$_POST[$parent] = clean($child);
       		}
 
-      		NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+      		NoCSRF::check( 'csrf_token', $_POST );
       		$cont = clean($_POST['content']);
       		$time = time();
 

--- a/applications/commands/conversations/reply.php
+++ b/applications/commands/conversations/reply.php
@@ -43,9 +43,10 @@
       				'message_type' => 2
       			);
 
-      			if( $MYSQL->insert('{prefix}messages', $data) ) {
+      			try {
+                    $MYSQL->insert('{prefix}messages', $data);
       				redirect(SITE_URL . '/conversations.php/cmd/view/v/' . $query['0']['id']);
-      			} else {
+      			} catch (mysqli_sql_exception $e) {
       				throw new Exception ($LANG['bb']['conversations']['error_sending_alt']);
       			}
 

--- a/applications/commands/members/activate.php
+++ b/applications/commands/members/activate.php
@@ -11,42 +11,43 @@
   $page_title = $LANG['bb']['members']['activate_account'];
 
   if( $PGET->g('code') ) {
-      
+
       $code = clean($PGET->g('code'));
       $MYSQL->where('date_joined', $code);
       $query = $MYSQL->get('{prefix}users');
-      
+
       if( !empty($query) ) {
-          
+
           if( $query['0']['user_disabled'] == 1 ) {
-              
+
               $data = array(
                   'user_disabled' => '0'
               );
               $MYSQL->where('id', $query['0']['id']);
-              
-              if( $MYSQL->update('{prefix}users', $data) ) {
+
+              try {
+                  $MYSQL->update('{prefix}users', $data);
                   $content = $TANGO->tpl->entity(
                       'success_notice',
                       'content',
                       $LANG['bb']['members']['account_activated']
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   $content = $TANGO->tpl->entity(
                       'danger_notice',
                       'content',
                       $LANG['bb']['members']['error_activating']
                   );
               }
-              
+
           } else {
               redirect(SITE_URL);
           }
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } else {
       redirect(SITE_URL);
   }

--- a/applications/commands/members/forgotpassword.php
+++ b/applications/commands/members/forgotpassword.php
@@ -49,7 +49,8 @@
               );
 
               $successful = false;
-              if ( $MYSQL->insert('{prefix}password_reset_requests', $data) ) {
+              try {
+                  $MYSQL->insert('{prefix}password_reset_requests', $data);
                   $to      = $email;
                   $subject = 'Password Reset';
                   $message = 'You have recently requested a password reset on ' . $TANGO->data['site_name'] . '. To set a new password, please use the following URL: ' . SITE_URL . '/members.php/cmd/resetpassword/token/' . urlencode($reset_token);
@@ -57,6 +58,8 @@
                              'Reply-To: ' . $TANGO->data['site_email'];
 
                   $successful = mail($to, $subject, $message, $headers);
+              } catch (mysqli_sql_exception $e) {
+                  $successful = false;
               }
 
               if ( $successful ) {

--- a/applications/commands/members/forgotpassword.php
+++ b/applications/commands/members/forgotpassword.php
@@ -21,7 +21,7 @@
 
           $email = $_POST['email'];
 
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
 
           if( !$email ) {
               throw new Exception ($LANG['global_form_process']['all_fields_required']);

--- a/applications/commands/members/register.php
+++ b/applications/commands/members/register.php
@@ -9,14 +9,14 @@
   if( $TANGO->sess->isLogged ){ redirect(SITE_URL); } //If user is logged in.
 
   $notice = '';
-      
+
         if( isset($_POST['register']) ) {
             try {
-                
+
                 foreach( $_POST as $parent => $child ) {
                     $_POST[$parent] = clean($child);
                 }
-                
+
                 NoCSRF::check('csrf_token', $_POST);//CSRF Checking.
                 $username   = $_POST['username'];
                 $password   = $_POST['password'];
@@ -24,7 +24,7 @@
                 $email      = $_POST['email'];
                 //preg_match('/^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$/', $email)
                 $time       = time();
-                
+
                 if( !$username or !$password or !$a_password or !$email ) {
                     throw new Exception ($LANG['global_form_process']['all_fields_required']);
                 } elseif( $password !== $a_password ) {
@@ -36,7 +36,7 @@
                 } elseif( emailTaken($email) ) {
                     throw new Exception ($LANG['global_form_process']['email_used']);
                 } else {
-                    
+
                     if( $TANGO->data['register_email_activate'] == "1" ) {
                         $data = array(
                             'username' => $username,
@@ -54,12 +54,13 @@
                             'user_disabled' => 0
                         );
                     }
-                    
-                    if( $MYSQL->insert('{prefix}users', $data) ) {
-                        
+
+                    try {
+                        $MYSQL->insert('{prefix}users', $data);
+
                         $email = 'You have registered on ' . $TANGO->data['site_name'] . '<br />
                                   Click <a href="' . SITE_URL . '/members.php/activate/code/' . $time . '">here</a> to activate your account.';
-                        
+
                         if( $TANGO->data['register_email_activate'] == "1" ) {
                             $MAIL->send('Account Activation', $email, 'Account Activation', $email);
                             $notice .= $TANGO->tpl->entity(
@@ -78,13 +79,13 @@
                                 $LANG['bb']['members']['register_successful']
                             );
                         }
-                        
-                    } else {
+
+                    } catch (mysqli_sql_exception $e) {
                         throw new Exception ($LANG['bb']['members']['error_register']);
                     }
-                    
+
                 }
-                
+
             } catch (Exception $e) {
                 $notice .= $TANGO->tpl->entity(
                     'danger_notice',
@@ -93,7 +94,7 @@
                 );
             }
         }
-        
+
         define('CSRF_TOKEN', NoCSRF::generate( 'csrf_token' ));
         //define('CSRF_INPUT', '<input type="hidden" name="csrf_token" value="' . CSRF_TOKEN . '">');
         /*$content = '<form action="" method="POST">

--- a/applications/commands/members/register.php
+++ b/applications/commands/members/register.php
@@ -17,7 +17,7 @@
                     $_POST[$parent] = clean($child);
                 }
                 
-                NoCSRF::check('csrf_token', $_POST, true, 60*10, true);//CSRF Checking.
+                NoCSRF::check('csrf_token', $_POST);//CSRF Checking.
                 $username   = $_POST['username'];
                 $password   = $_POST['password'];
                 $a_password = $_POST['a_password'];

--- a/applications/commands/members/resetpassword.php
+++ b/applications/commands/members/resetpassword.php
@@ -57,7 +57,8 @@ try {
             );
 
             $MYSQL->where('id', $user_id);
-            if ( $MYSQL->update('{prefix}users', $data) ) {
+            try {
+                $MYSQL->update('{prefix}users', $data);
                 // deactivate token
                 $data = array(
                     'active' => 0,
@@ -77,7 +78,7 @@ try {
 
                 $TANGO->sess->assign($query[0]['user_email']);
                 header('refresh:3;url=' . SITE_URL);
-            } else {
+            } catch (mysqli_sql_exception $e) {
                 throw new Exception ($LANG['bb']['members']['error_password_reset']);
             }
         }

--- a/applications/commands/members/resetpassword.php
+++ b/applications/commands/members/resetpassword.php
@@ -42,7 +42,7 @@ try {
             $_POST[$parent] = clean($child);
         }
 
-        NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+        NoCSRF::check( 'csrf_token', $_POST );
         $password   = $_POST['password'];
         $a_password = $_POST['a_password'];
 

--- a/applications/commands/profile/avatar.php
+++ b/applications/commands/profile/avatar.php
@@ -11,9 +11,9 @@
   $notice     = '';
 
   if( isset($_POST['edit']) ) {
-      
+
       try {
-          
+
           $mime  = array(
               'image/png',
               'image/jpeg',
@@ -22,7 +22,7 @@
           );
 
           $gravatar = ( isset($_POST['gravatar']) )? '1' : '0';
-          
+
          if( $gravatar == "1" ) {
 
              $data = array(
@@ -30,13 +30,14 @@
              );
              $MYSQL->where('id', $TANGO->sess->data['id']);
 
-             if( $MYSQL->update('{prefix}users', $data) ) {
+             try {
+                 $MYSQL->update('{prefix}users', $data);
                  $notice .= $TANGO->tpl->entity(
                     'success_notice',
                     'content',
                     $LANG['bb']['profile']['successful_adding_gravatar']
                  );
-             } else {
+             } catch (mysqli_sql_exception $e) {
                  throw new Exception ($LANG['bb']['profile']['error_adding_gravatar']);
              }
 
@@ -45,34 +46,35 @@
          } elseif( !in_array($_FILES['avatar']['type'], $mime) ) {
              throw new Exception ($LANG['global_form_process']['invalid_file_format']);
          } else {
-             
+
              $image   = $_FILES['avatar'];
              $bin_dir = 'public/img/bin/' . $TANGO->sess->data['id'] . '.png';
              //touch($bin_dir);
              copy($image['tmp_name'], $bin_dir);
              list($width, $height, $type, $attr) = getimagesize($bin_dir);
-             
+
              if( $width > 500 && $height > 500 ) {
                  throw new Exception ($LANG['global_form_process']['img_dimension_limit']);
              } else {
-                 
+
                  unlink($bin_dir);
                  $avatar_dir = 'public/img/avatars/' . $TANGO->sess->data['id'] . '.png';
                  if( copy($image['tmp_name'], $avatar_dir) ) {
-                     
+
                      $data = array(
                          'user_avatar' => $TANGO->sess->data['id'] . '.png',
                          'avatar_type' => '0'
                      );
                      $MYSQL->where('id', $TANGO->sess->data['id']);
-                     
-                     if( $MYSQL->update('{prefix}users', $data) ) {
+
+                     try {
+                         $MYSQL->update('{prefix}users', $data);
                          $notice .= $TANGO->tpl->entity(
                              'success_notice',
                              'content',
                              $LANG['bb']['profile']['successful_upload_avatar']
                          );
-                     } else {
+                     } catch (mysqli_sql_exception $e) {
                          $notice .= $TANGO->tpl->entity(
                              'success_notice',
                              'content',
@@ -82,11 +84,11 @@
                  } else {
                      throw new Exception ($LANG['bb']['profile']['error_upload_avatar']);
                  }
-                 
+
              }
-             
+
          }
-          
+
       } catch( Exception $e ) {
           $notice .= $TANGO->tpl->entity(
               'danger_notice',
@@ -94,7 +96,7 @@
               $e->getMessage()
           );
       }
-      
+
   }
 
   $gravatar_checked = ( $TANGO->sess->data['avatar_type'] == "1" )? ' checked' : '';

--- a/applications/commands/profile/edit.php
+++ b/applications/commands/profile/edit.php
@@ -18,7 +18,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $email = $_POST['email'];
           $tz    = $_POST['timezone'];
           $pass  = $_POST['confirm_password'];

--- a/applications/commands/profile/edit.php
+++ b/applications/commands/profile/edit.php
@@ -11,18 +11,18 @@
   $notice     = '';
 
   if( isset($_POST['edit']) ) {
-      
+
       try {
-          
+
           foreach( $_POST as $parent => $child ) {
               $_POST[$parent] = clean($child);
           }
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
           $email = $_POST['email'];
           $tz    = $_POST['timezone'];
           $pass  = $_POST['confirm_password'];
-          
+
           if( !$email or !$tz ) {
               throw new Exception ($LANG['global_form_process']['all_fields_required']);
           } elseif( !validEmail($email) ) {
@@ -31,7 +31,7 @@
               throw new Exception ($LANG['global_form_process']['invalid_password']);
           } else {
               if( $email !== $TANGO->sess->data['user_email'] ) {
-                  
+
                   if( !emailTaken($email) ) {
 
                       $data  = array(
@@ -39,21 +39,22 @@
                           'set_timezone' => $tz
                       );
                       $MYSQL->where('id', $TANGO->sess->data['id']);
-                      
-                      if( $MYSQL->update('{prefix}users', $data) ) {
+
+                      try {
+                          $MYSQL->update('{prefix}users', $data);
                           $notice .= $TANGO->tpl->entity(
                               'success_notice',
                               'content',
                               $LANG['global_form_process']['save_success']
                           );
-                      } else {
+                      } catch (mysqli_sql_exception $e) {
                           throw new Exception ($LANG['global_form_process']['error_saving']);
                       }
-                      
+
                   } else {
                       throw new Exception ($LANG['global_form_process']['email_used']);
                   }
-                  
+
               } else {
 
                   $data  = array(
@@ -61,19 +62,20 @@
                   );
                   $MYSQL->where('id', $TANGO->sess->data['id']);
 
-                  if( $MYSQL->update('{prefix}users', $data) ) {
+                  try {
+                    $MYSQL->update('{prefix}users', $data);
                     $notice .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
                       $LANG['global_form_process']['save_success']
                       );
-                  } else {
+                  } catch (mysqli_sql_exception $e) {
                     throw new Exception ($LANG['global_form_process']['error_saving']);
                   }
-                  
+
               }
           }
-          
+
       } catch( Exception $e ) {
           $notice .= $TANGO->tpl->entity(
               'danger_notice',
@@ -81,7 +83,7 @@
               $e->getMessage()
           );
       }
-      
+
   }
 
   define('CSRF_TOKEN', NoCSRF::generate( 'csrf_token' ));

--- a/applications/commands/profile/password.php
+++ b/applications/commands/profile/password.php
@@ -33,13 +33,14 @@
               );
               $MYSQL->where('id', $TANGO->sess->data['id']);
 
-              if( $MYSQL->update('{prefix}users', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}users', $data);
                   $notice .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
                       $LANG['global_form_process']['save_success']
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ($LANG['bb']['profile']['error_updating_password']);
               }
 

--- a/applications/commands/profile/password.php
+++ b/applications/commands/profile/password.php
@@ -18,7 +18,7 @@
               $_POST[$parent] = clean($child);
           }
 
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $new_password = $_POST['new_password'];
           $con_password = $_POST['current_password'];
 

--- a/applications/commands/profile/signature.php
+++ b/applications/commands/profile/signature.php
@@ -11,37 +11,38 @@
   $notice     = '';
 
   if( isset($_POST['edit']) ) {
-      
+
       try {
-          
+
           foreach( $_POST as $parent => $child ) {
               $_POST[$parent] = clean($child);
           }
-          
+
           NoCSRF::check( 'csrf_token', $_POST );
           $sig = $_POST['sig'];
-          
+
           if( !$sig ) {
               throw new Exception ($LANG['global_form_process']['all_fields_required']);
           } else {
-              
+
               $data = array(
                   'user_signature' => $sig
               );
               $MYSQL->where('id', $TANGO->sess->data['id']);
-              
-              if( $MYSQL->update('{prefix}users', $data) ) {
+
+              try {
+                  $MYSQL->update('{prefix}users', $data);
                   $notice .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
                       $LANG['global_form_process']['save_success']
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ($LANG['bb']['profile']['error_updating_signature']);
               }
-              
+
           }
-          
+
       } catch( Exception $e ) {
           $notice .= $TANGO->tpl->entity(
               'danger_notice',
@@ -49,12 +50,12 @@
               $e->getMessage()
           );
       }
-      
+
   }
 
   define('CSRF_TOKEN', NoCSRF::generate( 'csrf_token' ));
   //define('CSRF_INPUT', '<input type="hidden" name="csrf_token" value="' . CSRF_TOKEN . '">');
-  
+
   /*$content .= '<form id="tango_form" action="" method="POST">
                  ' . $FORM->build('hidden', '', 'csrf_token', array('value' => CSRF_TOKEN)) . '
                  <textarea id="editor" name="sig" style="width:100%;height:300px;max-width:100%;min-width:100%;">' . $TANGO->sess->data['user_signature'] . '</textarea>

--- a/applications/commands/profile/signature.php
+++ b/applications/commands/profile/signature.php
@@ -18,7 +18,7 @@
               $_POST[$parent] = clean($child);
           }
           
-          NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+          NoCSRF::check( 'csrf_token', $_POST );
           $sig = $_POST['sig'];
           
           if( !$sig ) {

--- a/applications/commands/profile/theme.php
+++ b/applications/commands/profile/theme.php
@@ -26,13 +26,14 @@
       );
       $MYSQL->where('id', $TANGO->sess->data['id']);
 
-      if( $MYSQL->update('{prefix}users', $data) ) {
+      try {
+        $MYSQL->update('{prefix}users', $data);
         $content = $TANGO->tpl->entity(
           'success_notice',
           'content',
           'Theme has been set!'
           );
-      } else {
+      } catch (mysqli_sql_exception $e) {
         $content = $TANGO->tpl->entity(
           'danger_notice',
           'content',

--- a/applications/libraries/mysqli.php
+++ b/applications/libraries/mysqli.php
@@ -64,8 +64,10 @@
 	public $queries_count;
 
 	public function __construct($host, $username, $password, $db, $prefix) {
-		$this->_mysqli = new mysqli($host, $username, $password, $db)
-			or die('There was a problem connecting to the database');
+        // throw exceptions in case of errors
+        $mysqli_driver = new mysqli_driver();
+        $mysqli_driver->report_mode = MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT;
+		$this->_mysqli = new mysqli($host, $username, $password, $db);
 		$this->_mysqli->set_charset('utf8');
 		self::$_instance = $this;
 		$this->_prefix = $prefix;

--- a/applications/libraries/permissions.php
+++ b/applications/libraries/permissions.php
@@ -6,7 +6,7 @@
   if( !defined('BASEPATH') ){ die(); }
 
   class Library_Permissions {
-      
+
       /*
        * Checks if the user has a certain permission.
        * SUCCESS - return true;
@@ -39,16 +39,17 @@
           $data = array(
             'permission_name' => $name
           );
-          if( $MYSQL->insert('{prefix}permissions', $data) ) {
+          try {
+              $MYSQL->insert('{prefix}permissions', $data);
             return true;
-          } else {
+          } catch (mysqli_sql_exception $e) {
             return false;
           }
         } else {
           return false;
         }
       }
-      
+
   }
 
 ?>

--- a/applications/libraries/terminal.php
+++ b/applications/libraries/terminal.php
@@ -3,11 +3,11 @@
   /*
    * Terminal Library
    */
- 
+
   if( !defined('BASEPATH') ){ die(); }
 
   class Library_Terminal {
-      
+
       /*
        * Check is command exists.
        */
@@ -35,13 +35,14 @@
           'command_syntax' => $syntax,
           'run_function' => $function
         );
-        if( $MYSQL->insert('{prefix}terminal', $data) ) {
+        try {
+            $MYSQL->insert('{prefix}terminal', $data);
           return true;
-        } else {
+        } catch (mysqli_sql_exception $e) {
           return false;
         }
       }
-      
+
   }
 
 ?>

--- a/applications/terminal/admin.php
+++ b/applications/terminal/admin.php
@@ -14,12 +14,13 @@
   			'user_group' => $g['id']
   		);
   		$MYSQL->where('username', $username);
-  		if( $MYSQL->update('{prefix}users', $data) ) {
+  		try {
+            $MYSQL->update('{prefix}users', $data);
   			return $ADMIN->alert(
   				'User\'s usergroup has been changed!',
   				'success'
   			);
-  		} else {
+  		} catch (mysqli_sql_exception $e) {
   			throw new Exception ('Error changing user\'s usergroup.');
   		}
   	}
@@ -32,12 +33,13 @@
   		'user_group' => BAN_ID
   	);
   	$MYSQL->where('username', $username);
-  	if( $MYSQL->update('{prefix}users', $data) ) {
+  	try {
+        $MYSQL->update('{prefix}users', $data);
   		return $ADMIN->alert(
   			'User has been banned!',
   			'success'
   		);
-  	} else {
+  	} catch (mysqli_sql_exception $e) {
   		throw new Exception ('Error banning user.');
   	}
   }
@@ -49,12 +51,13 @@
   		'user_group' => 1
   	);
   	$MYSQL->where('username', $username);
-  	if( $MYSQL->update('{prefix}users', $data) ) {
+  	try {
+        $MYSQL->update('{prefix}users', $data);
   		return $ADMIN->alert(
   			'User has been unbanned!',
   			'success'
   		);
-  	} else {
+  	} catch (mysqli_sql_exception $e) {
   		throw new Exception ('Error unbanning user.');
   	}
   }

--- a/edit.php
+++ b/edit.php
@@ -112,7 +112,7 @@
           if( isset($_POST['edit']) ) {
               try {
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   
                   //$con = $MYSQL->escape($_POST['content']);
                   //die($con);

--- a/install/step3.php
+++ b/install/step3.php
@@ -45,9 +45,10 @@
                     'site_email' => $email
                 );
 
-                if( $MYSQL->insert('{prefix}generic', $data) ) {
+                try {
+                    $MYSQL->insert('{prefix}generic', $data);
                     echo '<div class="alert alert-success">Success! <a href="step4.php">Continue</a>.</div>';
-                } else {
+                } catch (mysqli_sql_exception $e) {
                     throw new Exception ('Error adding data into database.');
                 }
 

--- a/install/step4.php
+++ b/install/step4.php
@@ -35,9 +35,10 @@
                   'user_group' => ADMIN_ID
               );
 
-              if( $MYSQL->insert('{prefix}users', $data) ) {
+              try {
+                  $MYSQL->insert('{prefix}users', $data);
                   echo '<div class="alert alert-success">TangoBB has been successfully installed! Please delete the installation folder.</div>';
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   throw new Exception ('Error inserting user into database!');
               }
 

--- a/mod/ban.php
+++ b/mod/ban.php
@@ -9,20 +9,21 @@
   $content    = '';
 
   if( $PGET->g('id') ) {
-      
+
       $MYSQL->where('id', $PGET->g('id'));
       $query = $MYSQL->get('{prefix}users');
-      
+
       if( !empty($query) ) {
-          
+
           if( $query['0']['is_banned'] == "0" ) {
-              
+
               $data = array(
                   'is_banned' => '1',
                   'user_group' => BAN_ID
               );
               $MYSQL->where('id', $PGET->g('id'));
-              if( $MYSQL->update('{prefix}users', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}users', $data);
                   $content .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
@@ -32,14 +33,14 @@
                         $LANG['mod']['ban']['ban_success']
                       )
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   $content .= $TANGO->tpl->entity(
                       'danger_notice',
                       'content',
                       $LANG['mod']['ban']['ban_error']
                   );
               }
-              
+
           } else {
               $content .= $TANGO->tpl->entity(
                   'danger_notice',
@@ -47,11 +48,11 @@
                   $LANG['mod']['ban']['already_banned']
               );
           }
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } else {
       redirect(SITE_URL);
   }

--- a/mod/close.php
+++ b/mod/close.php
@@ -9,19 +9,20 @@
   $content    = '';
 
   if( $PGET->g('thread') ) {
-      
+
       $MYSQL->where('id', $PGET->g('thread'));
       $query = $MYSQL->get('{prefix}forum_posts');
-      
+
       if( !empty($query) ) {
-          
+
           if( $query['0']['post_locked'] == "0" ) {
-              
+
               $data = array(
                   'post_locked' => '1'
               );
               $MYSQL->where('id', $PGET->g('thread'));
-              if( $MYSQL->update('{prefix}forum_posts', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}forum_posts', $data);
                   $content .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
@@ -31,14 +32,14 @@
                         $LANG['mod']['close']['close_success']
                       )
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   $content .= $TANGO->tpl->entity(
                       'danger_notice',
                       'content',
                       $LANG['mod']['close']['close_error']
                   );
               }
-              
+
           } else {
               $content .= $TANGO->tpl->entity(
                   'danger_notice',
@@ -46,11 +47,11 @@
                   $LANG['mod']['close']['already_closed']
               );
           }
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } else {
       redirect(SITE_URL);
   }

--- a/mod/open.php
+++ b/mod/open.php
@@ -9,19 +9,20 @@
   $content    = '';
 
   if( $PGET->g('thread') ) {
-      
+
       $MYSQL->where('id', $PGET->g('thread'));
       $query = $MYSQL->get('{prefix}forum_posts');
-      
+
       if( !empty($query) ) {
-          
+
           if( $query['0']['post_locked'] == "1" ) {
-              
+
               $data = array(
                   'post_locked' => '0'
               );
               $MYSQL->where('id', $PGET->g('thread'));
-              if( $MYSQL->update('{prefix}forum_posts', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}forum_posts', $data);
                   $content .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
@@ -31,14 +32,14 @@
                         $LANG['mod']['close']['open_success']
                       )
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   $content .= $TANGO->tpl->entity(
                       'danger_notice',
                       'content',
                       $LANG['mod']['close']['open_error']
                   );
               }
-              
+
           } else {
               $content .= $TANGO->tpl->entity(
                   'danger_notice',
@@ -46,11 +47,11 @@
                   $LANG['mod']['close']['already_opened']
               );
           }
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } else {
       redirect(SITE_URL);
   }

--- a/mod/stick.php
+++ b/mod/stick.php
@@ -9,19 +9,20 @@
   $content    = '';
 
   if( $PGET->g('thread') ) {
-      
+
       $MYSQL->where('id', $PGET->g('thread'));
       $query = $MYSQL->get('{prefix}forum_posts');
-      
+
       if( !empty($query) ) {
-          
+
           if( $query['0']['post_sticky'] == "0" ) {
-              
+
               $data = array(
                   'post_sticky' => '1'
               );
               $MYSQL->where('id', $PGET->g('thread'));
-              if( $MYSQL->update('{prefix}forum_posts', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}forum_posts', $data);
                   $content .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
@@ -31,14 +32,14 @@
                         $LANG['mod']['stick']['stick_success']
                       )
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   $content .= $TANGO->tpl->entity(
                       'danger_notice',
                       'content',
                       $LANG['mod']['stick']['stick_error']
                   );
               }
-              
+
           } else {
               $content .= $TANGO->tpl->entity(
                   'danger_notice',
@@ -46,11 +47,11 @@
                   $LANG['mod']['stick']['already_stuck']
               );
           }
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } else {
       redirect(SITE_URL);
   }

--- a/mod/unban.php
+++ b/mod/unban.php
@@ -9,20 +9,21 @@
   $content    = '';
 
   if( $PGET->g('id') ) {
-      
+
       $MYSQL->where('id', $PGET->g('id'));
       $query = $MYSQL->get('{prefix}users');
-      
+
       if( !empty($query) ) {
-          
+
           if( $query['0']['is_banned'] == "1" ) {
-              
+
               $data = array(
                   'is_banned' => '0',
                   'user_group' => '1'
               );
               $MYSQL->where('id', $PGET->g('id'));
-              if( $MYSQL->update('{prefix}users', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}users', $data);
                   $content .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
@@ -32,14 +33,14 @@
                         $LANG['mod']['ban']['unban_success']
                       )
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   $content .= $TANGO->tpl->entity(
                       'danger_notice',
                       'content',
                       $LANG['mod']['ban']['unban_error']
                   );
               }
-              
+
           } else {
               $content .= $TANGO->tpl->entity(
                   'danger_notice',
@@ -47,11 +48,11 @@
                   $LANG['mod']['ban']['already_unbanned']
               );
           }
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } else {
       redirect(SITE_URL);
   }

--- a/mod/unstick.php
+++ b/mod/unstick.php
@@ -9,19 +9,20 @@
   $content    = '';
 
   if( $PGET->g('thread') ) {
-      
+
       $MYSQL->where('id', $PGET->g('thread'));
       $query = $MYSQL->get('{prefix}forum_posts');
-      
+
       if( !empty($query) ) {
-          
+
           if( $query['0']['post_sticky'] == "1" ) {
-              
+
               $data = array(
                   'post_sticky' => '0'
               );
               $MYSQL->where('id', $PGET->g('thread'));
-              if( $MYSQL->update('{prefix}forum_posts', $data) ) {
+              try {
+                  $MYSQL->update('{prefix}forum_posts', $data);
                   $content .= $TANGO->tpl->entity(
                       'success_notice',
                       'content',
@@ -31,14 +32,14 @@
                         $LANG['mod']['stick']['unstick_success']
                       )
                   );
-              } else {
+              } catch (mysqli_sql_exception $e) {
                   $content .= $TANGO->tpl->entity(
                       'danger_notice',
                       'content',
                       $LANG['mod']['stick']['unstick_error']
                   );
               }
-              
+
           } else {
               $content .= $TANGO->tpl->entity(
                   'danger_notice',
@@ -46,11 +47,11 @@
                   $LANG['mod']['stick']['already_unstuck']
               );
           }
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } else {
       redirect(SITE_URL);
   }

--- a/new.php
+++ b/new.php
@@ -91,7 +91,7 @@
           if( isset($_POST['create']) ) {
               try {
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   $thread_title = clean($_POST['title']);
                   //die($_POST['content']);
                   $thread_cont  = $_POST['content'];

--- a/reply.php
+++ b/reply.php
@@ -16,14 +16,14 @@
   }
 
   if( $PGET->g('thread') ) {
-      
+
       $thread = clean($PGET->g('thread'));
       $MYSQL->where('post_type', '1');
       $MYSQL->where('id', $thread);
       $query = $MYSQL->get('{prefix}forum_posts');
-      
+
       if( !empty($query) ) {
-          
+
           $node        = node($query['0']['origin_node']);
           $breadcrumbs = $TANGO->tpl->entity(
             'breadcrumbs_before',
@@ -106,12 +106,12 @@
               $MYSQL->where('id', $PGET->g('quote'));
               $q_query = $MYSQL->get('{prefix}forum_posts');
           }
-          
+
           if( isset($_POST['reply']) ) {
               try {
-                  
+
                   //echo $_POST['csrf_token'] . '<br />' . $_SESSION['csrf_csrf_token'];
-                  
+
                   if( !empty($q_query) ) {
                       if( $_POST['csrf_token'] !== $_SESSION['tango_alt_csrf'] ) {
                           throw new Exception ('Invalid CSRF token!');
@@ -119,22 +119,22 @@
                   } else {
                       NoCSRF::check('csrf_token', $_POST);
                   }
-                  
+
                   $cont    = $_POST['content'];
                   $cont    = ( !empty($q_query) )? '[quote]' . $PGET->g('quote') . '[/quote]' . $cont : $cont;
-                  
+
 				  $data = array($TANGO->sess->data['id']);
                   $c_query = $MYSQL->rawQuery("SELECT * FROM {prefix}forum_posts WHERE post_user = ? ORDER BY post_time DESC LIMIT 1", $data);
-                  
+
                   if( !$cont ) {
                       throw new Exception ($LANG['global_form_process']['all_fields_required']);
                   } elseif( $c_query['0']['post_content'] == $cont ) {
                       throw new Exception ($LANG['global_form_process']['different_message_previous']);
                   } else {
-                      
+
                       $origin = thread($thread);
                       $time   = time();
-                      
+
                       $data = array(
                           'post_content' => $cont,
                           'post_time' => $time,
@@ -143,23 +143,24 @@
                           'origin_thread' => $thread,
                           'post_type' => '2'
                       );
-                      
+
                       if( $MYSQL->insert('{prefix}forum_posts', $data) ) {
                           $t_data = array(
                               'last_updated'=> $time
                           );
                           $MYSQL->where('id', $thread);
-                          if( $MYSQL->update('{prefix}forum_posts', $t_data) ) {
+                          try {
+                              $MYSQL->update('{prefix}forum_posts', $t_data);
                               redirect(SITE_URL . '/thread.php/v/' . $origin['title_friendly'] . '.' . $origin['id']);
-                          } else {
+                          } catch (mysqli_sql_exception $e) {
                               redirect(SITE_URL . '/thread.php/v/' . $origin['title_friendly'] . '.' . $origin['id']);
                           }
                       } else {
                           throw new Exception ($LANG['global_form_process']['error_replying_thread']);
                       }
-                      
+
                   }
-                  
+
               } catch ( Exception $e ) {
                   $notice .= $TANGO->tpl->entity(
                       'danger_notice',
@@ -168,13 +169,13 @@
                   );
               }
           }
-          
+
           if( !empty($q_query) ) {
               define('CSRF_TOKEN', alt_csrf());
           } else {
               define('CSRF_TOKEN', NoCSRF::generate( 'csrf_token' ));
           }
-          
+
           $quote_user = ( !empty($q_query) )? $TANGO->user($q_query['0']['post_user']) : '';
           $quote_post = ( !empty($q_query) )? $TANGO->tpl->entity(
               'quote_post',
@@ -187,7 +188,7 @@
                   $quote_user['username']
               )
           ) : '';
-             
+
           $content = $TANGO->tpl->entity(
               'reply_thread_page',
               array(
@@ -213,9 +214,9 @@
                   SITE_URL . '/thread.php/v/' . $query['0']['title_friendly'] . '.' . $query['0']['id']
               )
           );
-          
-          
-          
+
+
+
           $TANGO->tpl->addParam(
               array(
                   'page_title',
@@ -226,11 +227,11 @@
                   $notice . $content
               )
           );
-          
+
       } else {
           redirect(SITE_URL . '/404.php');
       }
-      
+
   } else {
       redirect(SITE_URL . '/404.php');
   }

--- a/reply.php
+++ b/reply.php
@@ -144,7 +144,8 @@
                           'post_type' => '2'
                       );
 
-                      if( $MYSQL->insert('{prefix}forum_posts', $data) ) {
+                      try {
+                          $MYSQL->insert('{prefix}forum_posts', $data);
                           $t_data = array(
                               'last_updated'=> $time
                           );
@@ -155,7 +156,7 @@
                           } catch (mysqli_sql_exception $e) {
                               redirect(SITE_URL . '/thread.php/v/' . $origin['title_friendly'] . '.' . $origin['id']);
                           }
-                      } else {
+                      } catch (mysqli_sql_exception $e) {
                           throw new Exception ($LANG['global_form_process']['error_replying_thread']);
                       }
 

--- a/reply.php
+++ b/reply.php
@@ -117,7 +117,7 @@
                           throw new Exception ('Invalid CSRF token!');
                       }
                   } else {
-                      NoCSRF::check('csrf_token', $_POST, true, 60*10, true);
+                      NoCSRF::check('csrf_token', $_POST);
                   }
                   
                   $cont    = $_POST['content'];

--- a/report.php
+++ b/report.php
@@ -24,7 +24,7 @@
                       $_POST[$parent] = clean($child);
                   }
                   
-                  NoCSRF::check( 'csrf_token', $_POST, true, 60*10, true );
+                  NoCSRF::check( 'csrf_token', $_POST );
                   $reason = $_POST['reason'];
                   
                   if( !$reason ) {

--- a/report.php
+++ b/report.php
@@ -7,30 +7,30 @@
   $TANGO->tpl->getTpl('page');
 
   if( $PGET->g('post') ) {
-      
+
       $post  = clean($PGET->g('post'));
       $MYSQL->where('id', $post);
       $query = $MYSQL->get('{prefix}forum_posts');
-      
+
       if( !empty($query) ) {
-          
+
           $notice  = '';
           $content = '';
-          
+
           if( isset($_POST['report']) ) {
               try {
-                  
+
                   foreach( $_POST as $parent => $child ) {
                       $_POST[$parent] = clean($child);
                   }
-                  
+
                   NoCSRF::check( 'csrf_token', $_POST );
                   $reason = $_POST['reason'];
-                  
+
                   if( !$reason ) {
                       throw new Exception ($LANG['global_form_process']['all_fields_required']);
                   } else {
-                      
+
                       $time = time();
                       $data = array(
                           'report_reason' => $reason,
@@ -38,19 +38,20 @@
                           'reported_post' => $post,
                           'reported_time' => $time
                       );
-                      
-                      if( $MYSQL->insert('{prefix}reports', $data) ) {
+
+                      try {
+                          $MYSQL->insert('{prefix}reports', $data);
                           $notice .= $TANGO->tpl->entity(
                               'success_notice',
                               'content',
                               $LANG['global_form_process']['report_create_success']
                           );
-                      } else {
+                      } catch (mysqli_sql_exception $e) {
                           throw new Exception ($LANG['global_form_process']['error_submitting_report']);
                       }
-                      
+
                   }
-                  
+
               } catch( Exception $e ) {
                   $notice .= $TANGO->tpl->entity(
                       'danger_notice',
@@ -59,10 +60,10 @@
                   );
               }
           }
-          
+
           define('CSRF_TOKEN', NoCSRF::generate( 'csrf_token' ));
           //define('CSRF_INPUT', '<input type="hidden" name="csrf_token" value="' . CSRF_TOKEN . '">');
-          
+
           /*$content .= '<form action="" id="tango_form" method="POST">
                          ' . CSRF_INPUT . '
                          <label for="reason">Reason</label>
@@ -76,7 +77,7 @@
                          <br /><br />
                          ' . $FORM->build('submit', '', 'report', array('value' => $LANG['bb']['form']['report'])) . '
                        </form>';
-          
+
           $TANGO->tpl->addParam(
               array(
                   'page_title',
@@ -87,11 +88,11 @@
                   $notice . $content
               )
           );
-          
+
       } else {
           redirect(SITE_URL);
       }
-      
+
   } elseif( $PGET->g('user') ) {
       /* Feature coming soon. */
       redirect(SITE_URL);


### PR DESCRIPTION
Currently, the code uses different indicators to determine failed queries. For example, an UPDATE query with no affected rows will count as an error, which doesn't make a lot of sense.

It's better to check for real SQL errors. This is done by telling MySQLi to throw exceptions in case of an error. Those exceptions can then be caught and replaced with custom error messages.
